### PR TITLE
 Add : User, Posts 엔티티, JPA repository 생성

### DIFF
--- a/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/posts/Feelings.java
+++ b/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/posts/Feelings.java
@@ -1,0 +1,10 @@
+package com.gdschanyang.todayfeelingbackend2.domain.posts;
+
+
+public enum Feelings {
+    SAD,    // 슬픔, 우울
+    ANGRY,  // 화남
+    HAPPY,  // 행복함, 기쁨
+    PROUD   // 뿌듯함
+
+}

--- a/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/posts/Posts.java
+++ b/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/posts/Posts.java
@@ -1,0 +1,30 @@
+package com.gdschanyang.todayfeelingbackend2.domain.posts;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Posts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Feelings feelings;
+
+    @Column(length = 500, nullable = false)
+    private String title;
+
+    // 글 작성은 선택적
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private String author;
+}

--- a/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/user/User.java
+++ b/src/main/java/com/gdschanyang/todayfeelingbackend2/domain/user/User.java
@@ -1,0 +1,22 @@
+package com.gdschanyang.todayfeelingbackend2.domain.user;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+
+}

--- a/src/main/java/com/gdschanyang/todayfeelingbackend2/repository/PostsRepository.java
+++ b/src/main/java/com/gdschanyang/todayfeelingbackend2/repository/PostsRepository.java
@@ -1,0 +1,18 @@
+package com.gdschanyang.todayfeelingbackend2.repository;
+
+import com.gdschanyang.todayfeelingbackend2.domain.posts.Posts;
+import com.gdschanyang.todayfeelingbackend2.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+
+    Posts save(Posts posts);
+
+    Optional<Posts> findById(Long id);
+    Optional<Posts> findByAuthor(String name);
+
+    List<Posts> findAll();
+}

--- a/src/main/java/com/gdschanyang/todayfeelingbackend2/repository/UserRepository.java
+++ b/src/main/java/com/gdschanyang/todayfeelingbackend2/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.gdschanyang.todayfeelingbackend2.repository;
+
+import com.gdschanyang.todayfeelingbackend2.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    User save(User user);
+
+    Optional<User> findById(Long id);
+    Optional<User> findByName(String name);
+
+    List<User> findAll();
+
+}


### PR DESCRIPTION
# feat: User, Posts 엔티티, JPA repository 생성 -#1

### 변경 사항

1. User, Posts 엔티티를 생성하였고, Feelings 는 긍정 2가지, 부정 2가지로 일단 만들었습니다.
2. Spring Data JPA repository interface 기본 함수만 만들어 놓았습니다.

<br/>

### 참고 사항

폴더 구조는 일단 domain, repository, service 로 나눠보았습니다.

<br/>

closed #1

